### PR TITLE
Update login.js

### DIFF
--- a/login.js
+++ b/login.js
@@ -17,7 +17,7 @@ async function delayTime(ms) {
   for (const account of accounts) {
     const { username, password, panelnum } = account;
 
-    const browser = await puppeteer.launch({ headless: false });
+    const browser = await puppeteer.launch();
     const page = await browser.newPage();
 
     let url = `https://panel${panelnum}.serv00.com/login/?next=/`;


### PR DESCRIPTION
解决了如下报错的问题

```
##***group***Run set -e  
�***36;1mset -e  �***0m
�***36;1mxvfb-run --server-args="-screen 0 1280x1024x24" node login.js�***0m
shell: /usr/bin/bash -e {0}
env:
  ACCOUNTS_JSON: ***
##***endgroup***
/home/runner/work/Serv00_Auto_Login/Serv00_Auto_Login/node_modules/@puppeteer/browsers/lib/cjs/launch.js:312
                reject(new Error(***
                       ^

Error: Failed to launch the browser process!
***2043:2043:1015/083317.045847:FATAL:zygote_host_impl_linux.cc(128)*** No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise seehttps://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
***1015/083317.053012:ERROR:file_io_posix.cc(145)*** open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
***1015/083317.053046:ERROR:file_io_posix.cc(145)*** open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)


TROUBLESHOOTING: https://pptr.dev/troubleshooting

    at ChildProcess.onClose (/home/runner/work/Serv00_Auto_Login/Serv00_Auto_Login/node_modules/@puppeteer/browsers/lib/cjs/launch.js:312:24)
    at ChildProcess.emit (node:events:531:35)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12)

Node.js v20.17.0
##***error***Process completed with exit code 1.
```